### PR TITLE
Implement depth-aware pruning and helper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Repomind
 
-`repomind.py` is a utility script that scans a Python code base and creates a JSON summary of the functions defined and the functions called in each file.
+`repomind.py` is a utility script that scans a Python code base and creates a JSON summary of the functions defined and the functions called in each file. Recent updates add depth-aware pruning, optional prompt context, a simple critic agent, and memory history compression.
 
 ## Features
 
@@ -9,6 +9,10 @@
 - For each kept Python file, lists all function definitions and the functions they call.
 - Records the number of functions and calls for quick inspection.
 - Saves the gathered information to a JSON file (defaults to `repomind_summary.json`).
+- Depth-aware pruning keeps small but heavily used modules.
+- If a `prompt_context.txt` file exists in the target repo, its contents are included in the summary.
+- A `critic_agent.py` helper can review the summary for potentially missing files.
+- Summaries are stored in `repomind_memory.json` with old entries compressed.
 
 ## Usage
 

--- a/critic_agent.py
+++ b/critic_agent.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def review_summary(summary_path: Path) -> None:
+    data: Dict = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    call_counts = data.get("call_counts", {})
+    kept = data.get("kept", {})
+    pruned = data.get("pruned", [])
+
+    issues = []
+    for file_path in pruned:
+        info = kept.get(file_path)
+        if info:
+            continue
+        # If any of its functions are referenced, raise an issue
+        # we don't know functions because pruned file info is not stored; skip
+
+    # Look for functions referenced but belonging to pruned files
+    for func, count in call_counts.items():
+        found = False
+        for k, info in kept.items():
+            if func in info.get("functions", []):
+                found = True
+                break
+        if not found and count >= 1:
+            issues.append(f"Function '{func}' is called {count} times but its definition was not kept.")
+
+    if not issues:
+        print("No obvious issues detected by critic agent.")
+    else:
+        print("Critic Agent Findings:")
+        for issue in issues:
+            print(f"- {issue}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Review repomind summary for possible issues")
+    parser.add_argument("summary", type=str, help="Path to summary JSON file")
+    args = parser.parse_args()
+
+    review_summary(Path(args.summary))

--- a/prompt_context.txt
+++ b/prompt_context.txt
@@ -1,0 +1,1 @@
+# This file can contain additional instructions or context for follow-up agents.

--- a/repomind.py
+++ b/repomind.py
@@ -4,9 +4,24 @@ import os
 import ast
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 EXCLUDE_PATTERNS = ["test", "__init__", "setup", "example"]
+# If a file's functions are called this many times across the project, keep it
+# even if it would normally be pruned.
+CALL_COUNT_THRESHOLD = 3
+
+# Optional file that can be supplied alongside the repo to provide additional
+# context for follow-up agents. If present, it will be embedded in the summary
+# JSON output under the key ``prompt_context``.
+def load_prompt_context(repo_path: Path) -> Optional[str]:
+    context_file = repo_path / "prompt_context.txt"
+    if context_file.exists():
+        try:
+            return context_file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+    return None
 
 class FunctionCallVisitor(ast.NodeVisitor):
     def __init__(self):
@@ -36,35 +51,87 @@ def should_prune(filepath: Path) -> bool:
     return any(pattern in name for pattern in EXCLUDE_PATTERNS)
 
 def explore_repo(repo_path: Path) -> Dict:
-    summary = {"kept": {}, "pruned": []}
+    """Walk the repository and build a summary with depth-aware pruning."""
+    summary: Dict[str, Dict] = {
+        "kept": {},
+        "pruned": [],
+        "call_counts": {},
+        "prompt_context": load_prompt_context(repo_path),
+    }
+
+    file_info: Dict[str, Dict[str, List[str]]] = {}
 
     for root, _, files in os.walk(repo_path):
         for file in files:
             if not file.endswith(".py"):
                 continue
             full_path = Path(root) / file
-
             if should_prune(full_path):
                 summary["pruned"].append(str(full_path))
                 continue
 
             funcs, calls = extract_functions_and_calls(full_path)
-            if not funcs:
-                summary["pruned"].append(str(full_path))
-                continue
+            file_info[str(full_path)] = {"functions": funcs, "calls": calls}
 
-            summary["kept"][str(full_path)] = {
-                "functions": funcs,
-                "calls": calls,
-                "num_functions": len(funcs),
-                "num_calls": len(calls)
-            }
+    # Compute how often each function is called across the project
+    function_call_counts: Dict[str, int] = {}
+    for data in file_info.values():
+        for call in data["calls"]:
+            function_call_counts[call] = function_call_counts.get(call, 0) + 1
 
+    # Decide to keep or prune files based on depth-aware usage
+    for fpath, data in file_info.items():
+        call_count = sum(function_call_counts.get(func, 0) for func in data["functions"])
+        data.update({
+            "num_functions": len(data["functions"]),
+            "num_calls": len(data["calls"]),
+            "total_call_count": call_count,
+        })
+
+        if data["functions"] or call_count >= CALL_COUNT_THRESHOLD:
+            summary["kept"][fpath] = data
+        else:
+            summary["pruned"].append(fpath)
+
+    summary["call_counts"] = function_call_counts
     return summary
 
 def save_summary(summary: Dict, out_path: Path):
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
+
+
+class MemoryManager:
+    """Persist and optionally compress previous summaries."""
+
+    def __init__(self, path: Path, max_entries: int = 5) -> None:
+        self.path = path
+        self.max_entries = max_entries
+        self.history = self._load_history()
+
+    def _load_history(self) -> List[Dict]:
+        if self.path.exists():
+            try:
+                return json.loads(self.path.read_text(encoding="utf-8"))
+            except Exception:
+                return []
+        return []
+
+    def _compress_summary(self, summary: Dict) -> Dict:
+        return {
+            "kept_files": len(summary.get("kept", {})),
+            "pruned_files": len(summary.get("pruned", [])),
+        }
+
+    def add_summary(self, summary: Dict) -> None:
+        self.history.append(summary)
+        if len(self.history) > self.max_entries:
+            oldest = self.history.pop(0)
+            self.history.insert(0, self._compress_summary(oldest))
+
+    def save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.history[-self.max_entries:], f, indent=2)
 
 def main():
     import argparse
@@ -76,6 +143,12 @@ def main():
     repo_path = Path(args.repo)
     summary = explore_repo(repo_path)
     save_summary(summary, Path(args.out))
+
+    # Update memory history alongside the repo
+    memory_path = repo_path / "repomind_memory.json"
+    manager = MemoryManager(memory_path)
+    manager.add_summary(summary)
+    manager.save()
 
     print(f"✅ Analysis complete. Saved to {args.out}")
 


### PR DESCRIPTION
## Summary
- add depth-aware pruning based on cross-file call counts
- load optional prompt context file
- keep memory of previous runs with compression
- add a critic agent to review summaries
- document new features

## Testing
- `python -m py_compile repomind.py critic_agent.py`
- `python repomind.py . --out test_summary.json`
- `python critic_agent.py test_summary.json`


------
https://chatgpt.com/codex/tasks/task_e_687ea3067114832f9d0e88152dbb49b3