### PR TITLE
Implement advanced repo insights

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,80 @@
+# 🧠 AGENT.md — Codex Maintainer Agent Role
+
+## Overview
+Codex is not just a coder in this system. It is your **dedicated codebase maintainer, cognitive assistant, and structural search agent**. This document defines the role, responsibilities, and interaction boundaries of the Codex agent within the Repomind system.
+
+---
+
+## 🧱 Role Definition
+
+**Codex serves two primary roles:**
+
+1. **🛠 Codebase Maintainer**  
+   Responsible for:
+   - Refactoring retained files
+   - Resolving missing function definitions flagged by the Critic Agent
+   - Generating new features or endpoints using only the `prompt_context.txt`
+   - Responding to specific editing requests within the structure retained by Repomind
+
+2. **🔍 Structural Code Searcher**  
+   Responsible for:
+   - Answering architectural and logic-based questions about the repo
+   - Tracing call flows, dependencies, or router logic
+   - Summarizing the purpose or behavior of retained files
+   - Explaining how key functions like `solve_dependencies()` or `include_router()` operate in context
+
+Codex **does not** operate on the full codebase directly. It works only through:
+- **`prompt_context.txt`** — compressed high-signal code
+- **`critic_output.txt`** — a list of gaps or missing definitions
+- **`repomind_summary.json`** — structural metadata and file scores
+
+---
+
+## 🔄 Workflow in the System
+
+```mermaid
+graph TD
+  A[Repomind] --> B[Retained Summary + Prompt Context]
+  B --> C[Codex Agent (Maintainer)]
+  B --> D[Critic Agent]
+  D --> E[Missing Definitions]
+  E --> C
+```
+
+---
+
+## 🧠 Codex Agent Tasks
+
+### ✅ Maintenance
+- Implement missing functions flagged by the critic
+- Refactor large files for clarity or modularity
+- Improve code structure or readability without altering core logic
+
+### 🔎 Structural Reasoning
+- Answer: “What is the role of `applications.py`?”
+- Trace: “Where does `get_dependant()` get called from?”
+- Suggest: “How could this repo modularize better?”
+
+### 🆕 Generation
+- Create new endpoints or CLI commands consistent with the retained style
+- Inject docstrings, types, or logging
+
+---
+
+## ⚠️ Operational Boundaries
+
+- Codex must **not hallucinate full repo context**
+- It should **prefer edits to retained files** unless explicitly told to expand
+- If a requested file/function is not in `prompt_context.txt`, Codex should:
+  - Flag it as missing
+  - Suggest restoring it via Repomind or the Critic Agent
+
+---
+
+## 🛑 Summary
+Codex is the acting intelligence in the loop—tasked with transforming **structure** into **functionality**. It reasons, repairs, refactors, and reflects.
+
+It is **not just a coder**.
+It is the **mind that sees what matters—and makes it real**.
+
+> “You give me the shape. I give you the function.”

--- a/critic_agent.py
+++ b/critic_agent.py
@@ -1,10 +1,9 @@
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 
-def review_summary(summary_path: Path) -> None:
-    data: Dict = json.loads(summary_path.read_text(encoding="utf-8"))
+def review_summary_data(data: Dict) -> List[str]:
 
     call_counts = data.get("call_counts", {})
     kept = data.get("kept", {})
@@ -27,6 +26,13 @@ def review_summary(summary_path: Path) -> None:
                 break
         if not found and count >= 1:
             issues.append(f"Function '{func}' is called {count} times but its definition was not kept.")
+
+    return issues
+
+
+def review_summary(summary_path: Path) -> None:
+    data: Dict = json.loads(summary_path.read_text(encoding="utf-8"))
+    issues = review_summary_data(data)
 
     if not issues:
         print("No obvious issues detected by critic agent.")

--- a/repomind.py
+++ b/repomind.py
@@ -4,7 +4,9 @@ import os
 import ast
 import json
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Iterable
+import subprocess
+import re
 
 EXCLUDE_PATTERNS = ["test", "__init__", "setup", "example"]
 # If a file's functions are called this many times across the project, keep it
@@ -50,7 +52,7 @@ def should_prune(filepath: Path) -> bool:
     name = filepath.name.lower()
     return any(pattern in name for pattern in EXCLUDE_PATTERNS)
 
-def explore_repo(repo_path: Path) -> Dict:
+def explore_repo(repo_path: Path) -> Tuple[Dict, Dict[str, Dict[str, List[str]]]]:
     """Walk the repository and build a summary with depth-aware pruning."""
     summary: Dict[str, Dict] = {
         "kept": {},
@@ -94,11 +96,123 @@ def explore_repo(repo_path: Path) -> Dict:
             summary["pruned"].append(fpath)
 
     summary["call_counts"] = function_call_counts
-    return summary
+    return summary, file_info
 
 def save_summary(summary: Dict, out_path: Path):
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
+
+
+def apply_critic_feedback(summary: Dict, file_info: Dict[str, Dict[str, List[str]]]) -> None:
+    """Use the critic agent to find missing functions and re-include their files."""
+    from critic_agent import review_summary_data
+
+    issues = review_summary_data(summary)
+    if not issues:
+        return
+
+    missing_funcs = []
+    for issue in issues:
+        m = re.search(r"Function '([^']+)'", issue)
+        if m:
+            missing_funcs.append(m.group(1))
+
+    readded = []
+    for func in missing_funcs:
+        for path, info in file_info.items():
+            if func in info.get("functions", []):
+                if path not in summary["kept"]:
+                    summary["kept"][path] = info
+                    if path in summary.get("pruned", []):
+                        summary["pruned"].remove(path)
+                    readded.append(path)
+                break
+
+    if readded:
+        print("\n🔁 Critic feedback re-included files:")
+        for p in readded:
+            print(f" - {p}")
+
+
+def build_call_graph(file_info: Dict[str, Dict[str, List[str]]], dot_path: Path, png_path: Optional[Path] = None) -> None:
+    """Generate a simple file-level call graph in DOT format and optionally PNG."""
+    lines = ["digraph G {"]
+    files = {os.path.basename(p): p for p in file_info.keys()}
+    for name in files:
+        lines.append(f'"{name}" [shape=box];')
+
+    edges = set()
+    for src_path, data in file_info.items():
+        src_name = os.path.basename(src_path)
+        for call in data.get("calls", []):
+            for dst_path, dst_data in file_info.items():
+                if call in dst_data.get("functions", []) and src_path != dst_path:
+                    dst_name = os.path.basename(dst_path)
+                    edges.add((src_name, dst_name))
+
+    for a, b in edges:
+        lines.append(f'"{a}" -> "{b}";')
+    lines.append("}")
+
+    dot_path.write_text("\n".join(lines), encoding="utf-8")
+
+    if png_path:
+        try:
+            subprocess.run(["dot", "-Tpng", str(dot_path), "-o", str(png_path)], check=False)
+        except FileNotFoundError:
+            pass
+
+
+def generate_summary_paragraph(summary: Dict) -> str:
+    """Return a short paragraph summarizing the repo."""
+    kept = summary.get("kept", {})
+    num_files = len(kept)
+    total_funcs = sum(len(info.get("functions", [])) for info in kept.values())
+    file_names = ", ".join(os.path.basename(f) for f in list(kept.keys())[:5])
+
+    base = (
+        f"The repository contains {num_files} important Python files with "
+        f"{total_funcs} functions. Notable modules include {file_names}."
+    )
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        try:
+            import openai
+
+            openai.api_key = api_key
+            prompt = base + " Summarize the structure and purpose of this repository in one paragraph."
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+            )
+            return resp.choices[0].message["content"].strip()
+        except Exception:
+            pass
+    return base
+
+
+def report_structural_drift(old: Dict, new: Dict) -> None:
+    """Compare two summaries and print messages about increased usage."""
+    old_counts = old.get("call_counts", {})
+    new_counts = new.get("call_counts", {})
+
+    messages: List[str] = []
+    for func, new_count in new_counts.items():
+        old_count = old_counts.get(func, 0)
+        if new_count > old_count:
+            # Check if func is retained
+            retained = any(func in info.get("functions", []) for info in new.get("kept", {}).values())
+            if not retained:
+                messages.append(
+                    f"Function {func} is used more now, but still not retained."
+                )
+
+    if messages:
+        print("\n🧠 Live Diff Awareness:")
+        for m in messages:
+            print(f"- {m}")
 
 
 class MemoryManager:
@@ -138,17 +252,35 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("repo", type=str, help="Path to the local repo to explore")
     parser.add_argument("--out", type=str, default="repomind_summary.json")
+    parser.add_argument("--callgraph", type=str, default=None, help="Optional path to write callgraph DOT file")
+    parser.add_argument("--diagram", type=str, default=None, help="Optional path to write callgraph diagram PNG")
+    parser.add_argument("--summary-text", type=str, default=None, help="Optional path to write repo summary paragraph")
     args = parser.parse_args()
 
     repo_path = Path(args.repo)
-    summary = explore_repo(repo_path)
+    summary, file_info = explore_repo(repo_path)
+
+    # Apply feedback from critic agent to re-include missed files
+    apply_critic_feedback(summary, file_info)
+
     save_summary(summary, Path(args.out))
+
+    if args.callgraph:
+        build_call_graph(file_info, Path(args.callgraph), Path(args.diagram) if args.diagram else None)
+
+    if args.summary_text:
+        paragraph = generate_summary_paragraph(summary)
+        Path(args.summary_text).write_text(paragraph, encoding="utf-8")
 
     # Update memory history alongside the repo
     memory_path = repo_path / "repomind_memory.json"
     manager = MemoryManager(memory_path)
+    previous = manager.history[-1] if manager.history else None
     manager.add_summary(summary)
     manager.save()
+
+    if previous:
+        report_structural_drift(previous, summary)
 
     print(f"✅ Analysis complete. Saved to {args.out}")
 


### PR DESCRIPTION
## Summary
- rework critic agent to expose `review_summary_data`
- let `repomind.py` re-include missed files based on critic output
- generate simple DOT/PNG call graphs
- optionally summarize retained files with an LLM
- detect structural drift between runs
- expose new CLI arguments
- add Codex maintainer role documentation

## Testing
- `python -m py_compile repomind.py critic_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_687eaaa6ac38832f9771d39c98d71969