### PR TITLE
Add TODO tracker and session log guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# 🧠 AGENT.md — Codex Maintainer Agent Role
+# 🧠 AGENTS.md — Codex Maintainer Agent Role
 
 ## Overview
 Codex is not just a coder in this system. It is your **dedicated codebase maintainer, cognitive assistant, and structural search agent**. This document defines the role, responsibilities, and interaction boundaries of the Codex agent within the Repomind system.
@@ -78,3 +78,13 @@ It is **not just a coder**.
 It is the **mind that sees what matters—and makes it real**.
 
 > “You give me the shape. I give you the function.”
+
+## 🔁 Session Log
+This file records notable Codex actions for traceability.
+
+Whenever `TODO.md` is updated or tasks are completed, append a brief note here.
+Use the following format:
+
+### Session YYYY-MM-DD
+- Bullet of what changed
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,34 @@
+# ✅ TODO.md — Documentation Spiral Plan
+
+## Current Focus
+- [ ] Document `bezier_interpolate()` and `scale_handle()` in `interpolation.py`
+- [ ] Add full class-level docstrings to `TimelineMobSlot` and `StaticMobSlot` in `mobslots.py`
+
+## Next Modules
+- [ ] `mobs.py` → focus on `CompositionMob`, `MasterMob`, `SourceMob`
+- [ ] `file.py` → document `open()`, `save()`, and how metadata is handled
+
+## Cleanup
+- [ ] Filter built-ins from Critic warnings
+- [ ] Archive `fastapi_summary.json`, `pyaaf2_callgraph.dot` if not in use
+
+## Guidelines
+- Use crisp, descriptive docstrings
+- Do not alter logic (doc pass only)
+- Each session should update this file
+
+🧠 Use Codex to Modify It Between Sessions
+At the end of every run, Codex can:
+
+✅ Check off what it just documented
+
+➕ Add new tasks based on critic suggestions
+
+🧠 Reflect: “I saw a function used 20× but not documented — should I add that to TODO.md?”
+
+🔁 Then Codex Updates AGENTS.md for Traceability
+Every time Codex edits something, it appends:
+
+### Session July 21
+- Documented: `scale_handle()` and `bezier_interpolate()` in `interpolation.py`
+- Updated: `TODO.md` to reflect completion


### PR DESCRIPTION
## Summary
- rename `AGENT.md` to `AGENTS.md`
- add a section about a session log
- introduce `TODO.md` for tracking documentation tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ec07f8bfc832f86ec78488eaf9f46